### PR TITLE
Separate out C code from Go code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,9 @@ GO := go
 BREW := brew
 endif
 
+CGO_ENABLED := 0
+export CGO_ENABLED
+
 .PHONY: all
 all: bin/non-release_$(ARCH)/audiofs.a bin/non-release_$(ARCH)/audiofs-cli
 

--- a/Makefile
+++ b/Makefile
@@ -15,21 +15,24 @@ GO := go
 BREW := brew
 endif
 
+NPROC := $(shell nproc 2>/dev/null || sysctl -n hw.logicalcpu)
+
 CGO_ENABLED := 0
 export CGO_ENABLED
 
 .PHONY: all
-all: bin/non-release_$(ARCH)/audiofs.a bin/non-release_$(ARCH)/audiofs-cli
+all: bin/non-release_$(ARCH)/audiofs-cli
 
 .PHONY: release
 ifeq ($(shell uname -s),Darwin)
 release:
-	arch -arch x86_64 make bin/release_x86_64/audiofs-cli bin/release_x86_64/audiofs.a bin/release_x86_64/audiofs.h
-	arch -arch arm64 make bin/release_arm64/audiofs-cli bin/release_arm64/audiofs.a bin/release_arm64/audiofs.h
+	arch -arch x86_64 make -j$(NPROC) bin/release_x86_64/audiofs-cli
+	arch -arch arm64 make -j$(NPROC) bin/release_arm64/audiofs-cli
 	mkdir -p bin/release_universal
 	lipo -create -output bin/release_universal/audiofs-cli bin/release_arm64/audiofs-cli bin/release_x86_64/audiofs-cli
+	lipo -create -output bin/release_universal/native bin/release_arm64/native bin/release_x86_64/native
 else
-release: bin/release_$(ARCH)/audiofs.a bin/release_$(ARCH)/audiofs-cli
+release: bin/release_$(ARCH)/audiofs-cli
 endif
 # The compile_commands.json file can be used to open native code in an IDE which supports them (such as CLion)
 .PHONY: native/compile_commands.json
@@ -58,21 +61,25 @@ native/dependencies/release_$(ARCH)/built/lib/libfftw3_audiofs.a:
 native/dependencies/non-release_$(ARCH)/built/lib/libfftw3_audiofs.a:
 	cd native && ./build_fftw.sh non-release
 
-.PHONY: bin/non-release_$(ARCH)/audiofs.a bin/non-release_$(ARCH)/audiofs.h
-bin/non-release_$(ARCH)/audiofs.a bin/non-release_$(ARCH)/audiofs.h: native/dependencies/non-release_$(ARCH)/built/lib/libavcodec-audiofs.a
-	$(GO) build --buildmode=c-archive -o $@ ./exports
+.PHONY: bin/non-release_$(ARCH)/native
+bin/non-release_$(ARCH)/native: native/dependencies/non-release_$(ARCH)/built/lib/libavcodec-audiofs.a
+	mkdir -p bin/non-release_$(ARCH)
+	cd native && ./build_native.sh non-release "$(ROOT_DIR)$@"
 
 .PHONY: bin/non-release_$(ARCH)/audiofs-cli
-bin/non-release_$(ARCH)/audiofs-cli: native/dependencies/non-release_$(ARCH)/built/lib/libavcodec-audiofs.a
+bin/non-release_$(ARCH)/audiofs-cli: native/dependencies/non-release_$(ARCH)/built/lib/libavcodec-audiofs.a bin/non-release_$(ARCH)/native
 	$(GO) build -o $@ ./cmd
 
-.PHONY: bin/release_$(ARCH)/audiofs.a bin/release_$(ARCH)/audiofs.h
-bin/release_$(ARCH)/audiofs.a bin/release_$(ARCH)/audiofs.h: native/dependencies/release_$(ARCH)/built/lib/libavcodec-audiofs.a
-	$(GO) build -tags release --buildmode=c-archive -o $@ ./exports
+.PHONY: bin/release_$(ARCH)/native
+bin/release_$(ARCH)/native: native/dependencies/release_$(ARCH)/built/lib/libavcodec-audiofs.a
+	mkdir -p bin/release_$(ARCH)
+	cd native && ./build_native.sh release "$(ROOT_DIR)$@"
+	strip "$@"
+
 
 .PHONY: bin/release_$(ARCH)/audiofs-cli
-bin/release_$(ARCH)/audiofs-cli: native/dependencies/release_$(ARCH)/built/lib/libavcodec-audiofs.a
-	$(GO) build -tags release -o $@ ./cmd
+bin/release_$(ARCH)/audiofs-cli: native/dependencies/release_$(ARCH)/built/lib/libavcodec-audiofs.a bin/release_$(ARCH)/native
+	$(GO) build -tags release -trimpath=true -buildvcs=true -ldflags="-s -w" -o $@ ./cmd
 
 .PHONY: clean
 clean:

--- a/cc_wrapper
+++ b/cc_wrapper
@@ -1,7 +1,7 @@
 #! /bin/bash
 
 dir="$(dirname "$(realpath "$0")")/native"
-set -- "gcc" "${@:1}" # Prepend GCC to invocation to be fully transparent
+set -- "clang" "${@:1}" # Prepend GCC to invocation to be fully transparent
 
 if file=($(printf "%s\n" "$@" | grep '\.c$'))
 then JSON="$(jq -cnR '[inputs|{directory:$pwd, arguments:[$ARGS.positional[]], file:.}]' --arg pwd "$PWD" --args -- "$@" <<< "${file}")"

--- a/cmd/audiofs-cli.go
+++ b/cmd/audiofs-cli.go
@@ -7,7 +7,7 @@ import (
 	_ "gitlab.com/t4cc0re/audiofs/config"
 	"gitlab.com/t4cc0re/audiofs/lib"
 	"gitlab.com/t4cc0re/audiofs/lib/types"
-	"gitlab.com/t4cc0re/audiofs/native"
+    //	"gitlab.com/t4cc0re/audiofs/native"
 	"gitlab.com/t4cc0re/audiofs/serve"
 	"gitlab.com/t4cc0re/audiofs/util"
 	"os"
@@ -88,15 +88,13 @@ func main() {
 						return nil
 					}
 					//file := args[0]
-					val, err := native.GetMetadataFromFile(file)
+					val, err := util.GetMetadataFromFile(file)
 					logrus.Printf("%+v\n", val)
 					logrus.Printf("%+v\n", err)
 					d, err := util.MarshallCompressed(val)
 					logrus.Printf("%d\n", len(d))
 					var a types.FileMetadata
 					logrus.Printf("%+v\n", util.UnmarshallCompressed(d, &a))
-					allocs, frees := native.GetAllocatorMetrics()
-					logrus.Printf("%+v, %+v\n", allocs, frees)
 					if len(a.Streams) > 0 {
 						fmt.Fprintf(os.Stdout, "%s\t%s\n", a.Streams[0].Chromaprint, file)
 					}
@@ -148,7 +146,7 @@ a count and a string.`,
 		level = logrus.WarnLevel
 	}
 	logrus.SetLevel(level)
-	native.ApplyLogrusLevel()
+//	native.ApplyLogrusLevel()
 
 	cmdImport.Flags().BoolVarP(&import_KeepOriginal, "keep", "k", true, "keep the original file")
 	cmdImport.Flags().BoolVarP(&importExists_CarefulDedupe, "careful", "c", true, "only dedupe a file if PCM audio is bit-for-bit identical")

--- a/cxx_wrapper
+++ b/cxx_wrapper
@@ -1,7 +1,7 @@
 #! /bin/bash
 
 dir="$(dirname "$(realpath "$0")")/native"
-set -- "g++" "${@:1}" # Prepend GCC to invocation to be fully transparent
+set -- "clang++" "${@:1}" # Prepend GCC to invocation to be fully transparent
 
 if file=($(printf "%s\n" "$@" | grep '\.c\(\|cc\|pp\)$'))
 then JSON="$(jq -cnR '[inputs|{directory:$pwd, arguments:[$ARGS.positional[]], file:.}]' --arg pwd "$PWD" --args -- "$@" <<< "${file}")"

--- a/lib/library.go
+++ b/lib/library.go
@@ -3,7 +3,7 @@ package lib
 import (
 	"fmt"
 	"gitlab.com/t4cc0re/audiofs/config"
-	_ "gitlab.com/t4cc0re/audiofs/native"
+//	_ "gitlab.com/t4cc0re/audiofs/native"
 )
 
 type Error struct {

--- a/native/build_ffmpeg.sh
+++ b/native/build_ffmpeg.sh
@@ -83,7 +83,23 @@ echo "running configure. This might take a moment..."
   --disable-ffplay\
   --disable-ffmpeg\
   --disable-shared\
+  --disable-avdevice\
+  --disable-swscale\
   --disable-everything\
+  --disable-vdpau\
+  --disable-v4l2-m2m \
+  --disable-vaapi\
+  --disable-vdpau\
+  --disable-videotoolbox\
+  --disable-vulkan\
+  --disable-cuda-llvm\
+  --disable-cuvid\
+  --disable-d3d11va\
+  --disable-dxva2\
+  --disable-ffnvcodec\
+  --disable-nvdec\
+  --disable-nvenc\
+  --disable-amf\
   $(decoders) \
   $(demuxers) \
   $(muxers) \

--- a/native/build_fftw.sh
+++ b/native/build_fftw.sh
@@ -35,3 +35,4 @@ make
 make install
 ln -s "${DEP_DIR}/built/lib/libfftw3.a" "${DEP_DIR}/built/lib/libfftw3_audiofs.a"
 sedi 's/-lfftw3/-lfftw3_audiofs/g' "${DEP_DIR}/built/lib/pkgconfig/fftw3.pc"
+ln -s "${DEP_DIR}/built/lib/pkgconfig/fftw3.pc" "${DEP_DIR}/built/lib/pkgconfig/fftw3_audiofs.pc"

--- a/native/build_native.sh
+++ b/native/build_native.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -eufo pipefail
+
+CFLAGS='-Werror=unused-result -pipe -Wall -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector --param=ssp-buffer-size=4 -m64 -mtune=generic -fPIC -flto -ffat-lto-objects -Bstatic'
+LDFLAGS='-framework VideoToolbox -framework CoreFoundation -framework CoreMedia -framework CoreVideo -framework CoreServices -liconv -lswresample-audiofs -lswscale-audiofs -lavformat-audiofs -lavutil-audiofs -lavcodec-audiofs -lavfilter-audiofs -lchromaprint_audiofs -lfftw3 -ljansson -lstdc++ -lm -lz -Bstatic -flto=full'
+CFLAGS="${CFLAGS} -O0 -g"
+
+if [[ $(uname -s ) == Darwin ]]; then
+    CFLAGS="${CFLAGS} -Idependencies/non-release_arm64/built/include -I/opt/homebrew/include"
+    LDFLAGS="${LDFLAGS} -Ldependencies/non-release_arm64/built/lib -L/opt/homebrew/lib"
+fi
+
+export CFLAGS
+export LDFLAGS
+
+clang -v -o ../bin/native $(find . -type file -maxdepth 1 -name '*.c') ${CFLAGS} ${LDFLAGS}

--- a/native/build_native.sh
+++ b/native/build_native.sh
@@ -9,7 +9,7 @@ export CC="${ROOT_DIR}cc_wrapper"
 OUTPUT="${2}"
 
 CFLAGS='-Werror=unused-result -pipe -Wall -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector --param=ssp-buffer-size=4 -m64 -mtune=generic -fPIC -static-libstdc++'
-LDFLAGS='-framework CoreFoundation -framework CoreMedia -framework CoreServices -liconv -lswresample-audiofs -lavformat-audiofs -lavutil-audiofs -lavcodec-audiofs -lavfilter-audiofs -lchromaprint_audiofs -lfftw3 -ljansson -lstdc++ -lm -lz'
+LDFLAGS='-lswresample-audiofs -lavformat-audiofs -lavutil-audiofs -lavcodec-audiofs -lavfilter-audiofs -lchromaprint_audiofs -lfftw3 -ljansson -lstdc++ -lm -lz'
 STATIC_FLAG='-static' 
 
 if [[ "arm64" == "$(uname -m)" ]]; then
@@ -34,7 +34,7 @@ fi
 if [[ $(uname -s ) == Darwin ]]; then
 STATIC_FLAG='-Bstatic'
     CFLAGS="${CFLAGS} -I${HOMEBREW}/include"
-    LDFLAGS="${LDFLAGS} -L${HOMEBREW}/lib"
+    LDFLAGS="${LDFLAGS} -framework CoreFoundation -framework CoreMedia -framework CoreServices -liconv -L${HOMEBREW}/lib"
 fi
 
 CFLAGS="${STATIC_FLAG} -I${DEP_DIR}/built/include ${CFLAGS}"

--- a/native/build_native.sh
+++ b/native/build_native.sh
@@ -2,16 +2,45 @@
 
 set -eufo pipefail
 
-CFLAGS='-Werror=unused-result -pipe -Wall -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector --param=ssp-buffer-size=4 -m64 -mtune=generic -fPIC -flto -ffat-lto-objects -Bstatic'
-LDFLAGS='-framework CoreFoundation -framework CoreMedia -framework CoreServices -liconv -lswresample-audiofs -lavformat-audiofs -lavutil-audiofs -lavcodec-audiofs -lavfilter-audiofs -lchromaprint_audiofs -lfftw3 -ljansson -lstdc++ -lm -lz -Bstatic -flto=full'
+NATIVE_ROOT="$(pwd)"
+ROOT_DIR="${NATIVE_ROOT}/../"
+
+export CC="${ROOT_DIR}cc_wrapper"
+OUTPUT="${2}"
+
+CFLAGS='-Werror=unused-result -pipe -Wall -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector --param=ssp-buffer-size=4 -m64 -mtune=generic -fPIC -static-libstdc++'
+LDFLAGS='-framework CoreFoundation -framework CoreMedia -framework CoreServices -liconv -lswresample-audiofs -lavformat-audiofs -lavutil-audiofs -lavcodec-audiofs -lavfilter-audiofs -lchromaprint_audiofs -lfftw3 -ljansson -lstdc++ -lm -lz'
+STATIC_FLAG='-static' 
+
+if [[ "arm64" == "$(uname -m)" ]]; then
+    HOMEBREW='/opt/homebrew'
+else
+    HOMEBREW='/usr/local'
+fi
+
+if [[ "release" == "${1}" ]]; then
+  echo 'Building release binary'
+
+DEP_DIR="${NATIVE_ROOT}/dependencies/release_$(uname -m)"
+  CFLAGS="${CFLAGS} -O3 -flto -ffat-lto-objects"
+  LDFLAGS="${LDFLAGS} -flto=full"
+else
+    echo 'building debug binary'
+DEP_DIR="${NATIVE_ROOT}/dependencies/non-release_$(uname -m)"
 CFLAGS="${CFLAGS} -O0 -g"
 
-if [[ $(uname -s ) == Darwin ]]; then
-    CFLAGS="${CFLAGS} -Idependencies/non-release_arm64/built/include -I/opt/homebrew/include"
-    LDFLAGS="${LDFLAGS} -Ldependencies/non-release_arm64/built/lib -L/opt/homebrew/lib"
 fi
+
+if [[ $(uname -s ) == Darwin ]]; then
+STATIC_FLAG='-Bstatic'
+    CFLAGS="${CFLAGS} -I${HOMEBREW}/include"
+    LDFLAGS="${LDFLAGS} -L${HOMEBREW}/lib"
+fi
+
+CFLAGS="${STATIC_FLAG} -I${DEP_DIR}/built/include ${CFLAGS}"
+LDFLAGS="${STATIC_FLAG} -L${DEP_DIR}/built/lib ${LDFLAGS}"
 
 export CFLAGS
 export LDFLAGS
 
-clang -v -o ../bin/native $(find . -type file -maxdepth 1 -name '*.c') ${CFLAGS} ${LDFLAGS}
+"${CC}" -o "${OUTPUT}" ${CFLAGS} ${LDFLAGS} $(find . -type file -maxdepth 1 -name '*.c')

--- a/native/build_native.sh
+++ b/native/build_native.sh
@@ -43,4 +43,4 @@ LDFLAGS="${STATIC_FLAG} -L${DEP_DIR}/built/lib ${LDFLAGS}"
 export CFLAGS
 export LDFLAGS
 
-"${CC}" -o "${OUTPUT}" ${CFLAGS} ${LDFLAGS} $(find . -type file -maxdepth 1 -name '*.c')
+"${CC}" -o "${OUTPUT}" ${CFLAGS} ${LDFLAGS} $(find . -type f -maxdepth 1 -name '*.c')

--- a/native/build_native.sh
+++ b/native/build_native.sh
@@ -9,7 +9,7 @@ export CC="${ROOT_DIR}cc_wrapper"
 OUTPUT="${2}"
 
 CFLAGS='-Werror=unused-result -pipe -Wall -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector --param=ssp-buffer-size=4 -m64 -mtune=generic -fPIC -static-libstdc++'
-LDFLAGS='-lswresample-audiofs -lavformat-audiofs -lavutil-audiofs -lavcodec-audiofs -lavfilter-audiofs -lchromaprint_audiofs -lfftw3 -ljansson -lstdc++ -lm -lz'
+LDFLAGS='-lswresample-audiofs -lavformat-audiofs -lavutil-audiofs -lavcodec-audiofs -lavfilter-audiofs -lchromaprint_audiofs -lfftw3_audiofs -ljansson -lstdc++ -lm -lz'
 STATIC_FLAG='-static' 
 
 if [[ "arm64" == "$(uname -m)" ]]; then
@@ -22,7 +22,7 @@ if [[ "release" == "${1}" ]]; then
   echo 'Building release binary'
 
 DEP_DIR="${NATIVE_ROOT}/dependencies/release_$(uname -m)"
-  CFLAGS="${CFLAGS} -O3 -flto -ffat-lto-objects"
+  CFLAGS="${CFLAGS} -DAUDIOFS_NO_TRACE=1 -O3 -flto -ffat-lto-objects"
   LDFLAGS="${LDFLAGS} -flto=full"
 else
     echo 'building debug binary'
@@ -35,6 +35,9 @@ if [[ $(uname -s ) == Darwin ]]; then
 STATIC_FLAG='-Bstatic'
     CFLAGS="${CFLAGS} -I${HOMEBREW}/include"
     LDFLAGS="${LDFLAGS} -framework CoreFoundation -framework CoreMedia -framework CoreServices -liconv -L${HOMEBREW}/lib"
+else
+    CFLAGS="${CFLAGS} -fuse-ld=lld"
+    LDFLAGS="-Wl,--start-group ${LDFLAGS} -Wl,--end-group"
 fi
 
 CFLAGS="${STATIC_FLAG} -I${DEP_DIR}/built/include ${CFLAGS}"

--- a/native/build_native.sh
+++ b/native/build_native.sh
@@ -3,7 +3,7 @@
 set -eufo pipefail
 
 CFLAGS='-Werror=unused-result -pipe -Wall -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector --param=ssp-buffer-size=4 -m64 -mtune=generic -fPIC -flto -ffat-lto-objects -Bstatic'
-LDFLAGS='-framework VideoToolbox -framework CoreFoundation -framework CoreMedia -framework CoreVideo -framework CoreServices -liconv -lswresample-audiofs -lswscale-audiofs -lavformat-audiofs -lavutil-audiofs -lavcodec-audiofs -lavfilter-audiofs -lchromaprint_audiofs -lfftw3 -ljansson -lstdc++ -lm -lz -Bstatic -flto=full'
+LDFLAGS='-framework CoreFoundation -framework CoreMedia -framework CoreServices -liconv -lswresample-audiofs -lavformat-audiofs -lavutil-audiofs -lavcodec-audiofs -lavfilter-audiofs -lchromaprint_audiofs -lfftw3 -ljansson -lstdc++ -lm -lz -Bstatic -flto=full'
 CFLAGS="${CFLAGS} -O0 -g"
 
 if [[ $(uname -s ) == Darwin ]]; then

--- a/native/libav.c
+++ b/native/libav.c
@@ -425,3 +425,21 @@ end:
 
     return json_str;
 }
+
+#ifndef AUDIOFS_CGO
+
+int main(int argc, char **argv) {
+    if (argc < 2) {
+        errorf("Usage: %s <input file> <output file>\n", argv[0]);
+        return 1;
+    }
+
+    const char* json = get_metadate_from_file(argv[1]);
+
+    if (json == NULL) {
+        return 1;
+    }
+    fprintf(stdout, "%s\n", json);
+    return 0;
+}
+#endif

--- a/native/macros.h
+++ b/native/macros.h
@@ -125,7 +125,7 @@ extern uint64_t        c_frees;
 __attribute__((__warn_unused_result__)) __attribute__((always_inline)) __attribute__((used)) static inline void *
 AUDIOFS_CALLOC_NO_TRACE(int count, size_t size) {
     void *ptr = calloc(count, (size_t)(size));
-    if (ptr > 0) { c_allocs += count * size; }
+//    if (ptr > 0) { c_allocs += count * size; }
     return ptr;
 }
 // Use zero-initialized calloc rather than malloc
@@ -135,7 +135,6 @@ AUDIOFS_CALLOC_NO_TRACE(int count, size_t size) {
 #define AUDIOFS_FREE_NO_TRACE(ptr)                      \
     {                                                   \
         if ((ptr) != NULL) {                            \
-            c_frees += portable_ish_malloced_size(ptr); \
             free(ptr);                                  \
             (ptr) = NULL;                               \
         }                                               \

--- a/native/transcode.c
+++ b/native/transcode.c
@@ -653,14 +653,3 @@ end:
 
     return handle;
 }
-#ifndef AUDIOFS_CGO
-
-int main(int argc, char **argv) {
-    if (argc != 3) {
-        errorf("Usage: %s <input file> <output file>\n", argv[0]);
-        return 1;
-    }
-
-    return do_transcode(argv[1], argv[2], NULL, NULL, "aiff");
-}
-#endif

--- a/native/util.h
+++ b/native/util.h
@@ -130,8 +130,8 @@ audiofs_buffer_realloc(audiofs_buffer *buffer, uint64_t size) {
         if (buffer->len > size) { memset(new_ptr + buffer->len, 0, buffer->len - size); }
         buffer->len  = size;
         buffer->data = new_ptr;
-        c_frees += portable_ish_malloced_size(buffer->data);
-        c_allocs += size;
+       // c_frees += portable_ish_malloced_size(buffer->data);
+       // c_allocs += size;
     }
 
     // emergency check to provide guarantee:

--- a/util/InvokeNative.go
+++ b/util/InvokeNative.go
@@ -1,22 +1,28 @@
 package util
 
 import (
-    "encoding/json"
+	"encoding/json"
 	"errors"
-	"github.com/sirupsen/logrus"
-//	"gitlab.com/t4cc0re/audiofs/config"
-	"gitlab.com/t4cc0re/audiofs/lib/types"
+	"os"
 	"os/exec"
+	"path"
+	"path/filepath"
 
+	"github.com/sirupsen/logrus"
+	"gitlab.com/t4cc0re/audiofs/lib/types"
 )
 
+func GetMetadataFromFile(file string) (*types.FileMetadata, error) {
 
-func GetMetadataFromFile(path string) (*types.FileMetadata, error) {
-
-	JSON, err := exec.Command("./bin/native", path).Output()
+	ex, err := os.Executable()
+	if err != nil {
+		panic(err)
+	}
+	exPath := filepath.Dir(ex)
+	JSON, err := exec.Command(path.Join(exPath, "native"), file).Output()
 	if err != nil {
 		logrus.Errorf("%+v", err)
-        return nil, err
+		return nil, err
 	}
 
 	val := types.FileMetadata{}
@@ -27,5 +33,3 @@ func GetMetadataFromFile(path string) (*types.FileMetadata, error) {
 
 	return &val, nil
 }
-
-

--- a/util/InvokeNative.go
+++ b/util/InvokeNative.go
@@ -1,0 +1,31 @@
+package util
+
+import (
+    "encoding/json"
+	"errors"
+	"github.com/sirupsen/logrus"
+//	"gitlab.com/t4cc0re/audiofs/config"
+	"gitlab.com/t4cc0re/audiofs/lib/types"
+	"os/exec"
+
+)
+
+
+func GetMetadataFromFile(path string) (*types.FileMetadata, error) {
+
+	JSON, err := exec.Command("./bin/native", path).Output()
+	if err != nil {
+		logrus.Errorf("%+v", err)
+        return nil, err
+	}
+
+	val := types.FileMetadata{}
+	err = json.Unmarshal([]byte(JSON), &val)
+	if err != nil {
+		return nil, errors.Join(err, errors.New("unknown"))
+	}
+
+	return &val, nil
+}
+
+


### PR DESCRIPTION
We should separate the code to better shield the memory-safe code in Go from potential corruptions of the C code.

This is done in multiple steps.

The first step (this PR) is to extract metadata extraction into a single binary executed for each file to analyze.

Later, this should be replaced with a socket or FIFO communication way, so that the C code runs as a backend server of sorts, to prevent the overhead of constant re-execution of the binary.

Finally, the file to analyze should be streamed to the C process from Go, so that the C code does not require permission to access the filesystem and can be sandboxed via seccomp or similar.